### PR TITLE
set go version to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/greenbone/go-project-template
 
-go 1.16
+go 1.18


### PR DESCRIPTION
Go Version is set to 1.18 to conform architecture guidelines

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a ] Tests
